### PR TITLE
Bug with begin/end in CV

### DIFF
--- a/lib/AnyEvent/Memcached.pm
+++ b/lib/AnyEvent/Memcached.pm
@@ -300,6 +300,7 @@ sub _do {
 		
 		$_ and $_->end for $args{cv}, $self->{cv};
 	};
+	$cv->begin;
 	for my $srv ( keys %$servers ) {
 		for my $real (@{ $servers->{$srv} }) {
 			$cv->begin;
@@ -327,6 +328,7 @@ sub _do {
 			);
 		}
 	}
+	$cv->end;
 	return;
 }
 


### PR DESCRIPTION
This is the general pattern when you "fan out" into multiple (but potentially zero) subrequests: use an outer begin/end pair to set the callback and ensure end is called at least once, and then, for each subrequest you start, call begin and for each subrequest you finish, call end.