### PR TITLE
Bug with use begin/end

### DIFF
--- a/lib/AnyEvent/Memcached.pm
+++ b/lib/AnyEvent/Memcached.pm
@@ -408,6 +408,7 @@ sub _set {
 		
 		$_ and $_->end for $args{cv}, $self->{cv};
 	};
+	$cv->begin;
 	for my $srv ( keys %$servers ) {
 		# ??? Can hasher return more than one key for single key passed?
 		# If no, need to remove this inner loop
@@ -445,6 +446,7 @@ sub _set {
 			);
 		}
 	}
+	$cv->end;
 	return;
 }
 
@@ -592,6 +594,7 @@ sub _get {
 		$args{cb}( $array ? \%res :  $res{ $keys } );
 		$_ and $_->end for $args{cv}, $self->{cv};
 	};
+	$cv->begin;
 	for my $srv ( keys %$servers ) {
 		#warn "server for $key = $srv, $self->{peers}{$srv}";
 		$cv->begin;
@@ -601,6 +604,7 @@ sub _get {
 			$cv->end;
 		});
 	}
+	$cv->end;
 	return;
 }
 sub get  { shift->_get(get => @_) }


### PR DESCRIPTION
This is the general pattern when you "fan out" into multiple (but potentially zero) subrequests: use an outer begin/end pair to set the callback and ensure end is called at least once, and then, for each subrequest you start, call begin and for each subrequest you finish, call end.